### PR TITLE
Feature/custom stats

### DIFF
--- a/forge/workflows/allegro_configs/base.yaml
+++ b/forge/workflows/allegro_configs/base.yaml
@@ -38,7 +38,7 @@ data:
   test_dataloader: ${data.val_dataloader}
 
   stats_manager:
-    _target_: nequip.data.CommonDataStatisticsManager
+    _target_: forge.workflows.allegro_utils.ExtendedDataStatisticsManager
     type_names: ['Ti', 'V', 'Cr', 'Zr', 'W']
 
 trainer:

--- a/forge/workflows/allegro_utils/__init__.py
+++ b/forge/workflows/allegro_utils/__init__.py
@@ -13,6 +13,7 @@ from .callbacks import CurriculumCallback, GradNormCallback
 from .custom_metrics import TailMSE, FocalMSELoss, TailHuberLoss, ForceAngleLoss, StressShearMAE, StressAngleLoss
 from .weighted_loss import WeightedMSELoss, RareWeightedMetricsManager
 from .pair_potential import NLH
+from .custom_stats import ExtendedDataStatisticsManager
 
 # Alias V3 as the standard CustomSamplingASEDataModule
 CustomSamplingASEDataModule = CustomSamplingASEDataModuleV3
@@ -38,4 +39,7 @@ __all__ = [
 
     # Pair Potential
     'NLH',
+
+    # Custom Stats
+    'ExtendedDataStatisticsManager',
 ] 

--- a/forge/workflows/allegro_utils/custom_metrics.py
+++ b/forge/workflows/allegro_utils/custom_metrics.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 from torchmetrics import Metric
 from nequip.data import AtomicDataDict
 from nequip.data.stats import _MeanX
+from nequip.train.metrics import StratifiedHuberForceLoss
 
 class TailMSE(_MeanX):
     """Computes a running mean of the Mean Squared Error on the tail of an error distribution.
@@ -58,6 +59,36 @@ class TailMSE(_MeanX):
         tail_err = err[tail_mask]
         squared_errors = tail_err.pow(2)
         super().update(squared_errors)
+
+class AutoStratifiedHuberLoss(StratifiedHuberForceLoss):
+    """A StratifiedHuberForceLoss that constructs its delta_dict from lists.
+
+    This class is a convenience wrapper around NequIP's `StratifiedHuberForceLoss`.
+    Instead of requiring a pre-constructed `delta_dict`, it takes two lists,
+    `boundaries` and `deltas`, and builds the dictionary for you.
+
+    This is particularly useful when the boundaries and deltas are computed
+    dynamically and injected into a configuration file.
+
+    Args:
+        boundaries (List[float]): A list of lower bounds for force magnitudes.
+        deltas (List[float]): A list of delta values for the Huber loss in each stratum.
+        **kwargs: Additional keyword arguments for the parent class.
+    """
+    def __init__(self, boundaries: List[float], deltas: List[float], **kwargs):
+        if len(boundaries) + 1 != len(deltas):
+            raise ValueError(
+                f"Number of deltas must be one greater than the number of boundaries. "
+                f"Got {len(deltas)} deltas and {len(boundaries)} boundaries."
+            )
+        
+        # The first delta corresponds to the region below the first boundary.
+        # The first boundary in the dict should be 0.
+        delta_dict = {0.0: deltas[0]}
+        for i, boundary in enumerate(boundaries):
+            delta_dict[boundary] = deltas[i+1]
+        
+        super().__init__(delta_dict=delta_dict, **kwargs)
 
 class TailHuberLoss(_MeanX):
     """Computes a running mean of the Huber loss on the tail of the force error distribution.

--- a/forge/workflows/allegro_utils/custom_stats.py
+++ b/forge/workflows/allegro_utils/custom_stats.py
@@ -4,9 +4,8 @@ from torchmetrics import Metric
 from nequip.data import AtomicDataDict
 from nequip.data.modifier import BaseModifier, PerAtomModifier, NumNeighbors
 from nequip.data.stats import Mean, RootMeanSquare, StandardDeviation, _MeanX
-from nequip.data.dataloader import Collater
+from nequip.data.stats_manager import DataStatisticsManager
 from nequip.utils.logger import RankedLogger
-from nequip.data.stats import DataStatisticsManager
 
 
 logger = RankedLogger(__name__, rank_zero_only=True)
@@ -63,7 +62,6 @@ class ForceMagnitude(BaseModifier):
     """A modifier to compute the magnitude of force vectors."""
     def __init__(self, field: str = AtomicDataDict.FORCE_KEY):
         super().__init__(field=field)
-        self.type = "node"
 
     def forward(self, data: AtomicDataDict.Type) -> torch.Tensor:
         forces = super().forward(data)

--- a/forge/workflows/allegro_utils/custom_stats.py
+++ b/forge/workflows/allegro_utils/custom_stats.py
@@ -28,31 +28,20 @@ class Quantile(Metric):
         if not 0.0 <= q <= 1.0:
             raise ValueError(f"Quantile `q` must be between 0 and 1, but got {q}")
         self.q = q
-        self.add_state("data", default=[], dist_reduce_fx="cat")
+        self.add_state("data", default=torch.tensor([]), dist_reduce_fx="cat")
 
     def update(self, data: torch.Tensor) -> None:
-        """Append data to the state."""
+        """Append data to the state tensor."""
         if data.numel() > 0:
-            self.data.append(data.flatten())
+            # Ensure data is on the same device as the state tensor before concatenating
+            self.data = torch.cat([self.data, data.flatten().to(self.data.device)])
 
     def compute(self) -> torch.Tensor:
         """Compute the quantile of all collected data."""
-        if not self.data:
-            return torch.tensor(float('nan'))
-        
-        # On DDP, self.data will be a list of lists of tensors, so flatten it
-        if any(isinstance(i, list) for i in self.data):
-             all_data = [item for sublist in self.data for item in sublist]
-        else:
-            all_data = self.data
-        
-        if not all_data:
+        if self.data.numel() == 0:
             return torch.tensor(float('nan'))
             
-        data_cat = torch.cat(all_data)
-        if data_cat.numel() == 0:
-            return torch.tensor(float('nan'))
-        return torch.quantile(data_cat.to(torch.float32), self.q)
+        return torch.quantile(self.data.to(torch.float32), self.q)
 
     def __str__(self) -> str:
         return f"q_{self.q}"

--- a/forge/workflows/allegro_utils/custom_stats.py
+++ b/forge/workflows/allegro_utils/custom_stats.py
@@ -10,7 +10,10 @@ from nequip.train.metrics import StratifiedHuberForceLoss
 from nequip.utils.logger import RankedLogger
 from tqdm.auto import tqdm
 import sys
+import random
 
+random.seed(42)
+torch.manual_seed(42)
 
 logger = RankedLogger(__name__, rank_zero_only=True)
 
@@ -145,10 +148,10 @@ def ExtendedDataStatisticsManager(
         {"name": "forces_rms", "field": AtomicDataDict.FORCE_KEY, "metric": RootMeanSquare()},
         {"name": "per_type_forces_rms", "field": AtomicDataDict.FORCE_KEY, "metric": RootMeanSquare(), "per_type": True},
         # Extended stats for loss parameters
-        {"name": "force_magnitude_q10", "field": ForceMagnitude(), "metric": Quantile(0.10)},
-        {"name": "force_magnitude_q50", "field": ForceMagnitude(), "metric": Quantile(0.50)},
-        {"name": "force_magnitude_q90", "field": ForceMagnitude(), "metric": Quantile(0.90)},
-        {"name": "force_magnitude_q95", "field": ForceMagnitude(), "metric": Quantile(0.95)},
+        {"name": "force_magnitude_q10", "field": ForceMagnitude(), "metric": Quantile(0.10, buffer_size=1000)},
+        {"name": "force_magnitude_q50", "field": ForceMagnitude(), "metric": Quantile(0.50, buffer_size=1000)},
+        {"name": "force_magnitude_q90", "field": ForceMagnitude(), "metric": Quantile(0.90, buffer_size=1000)},
+        {"name": "force_magnitude_q95", "field": ForceMagnitude(), "metric": Quantile(0.95, buffer_size=1000)},
     ]
     
     base_manager = DataStatisticsManager(metrics, dataloader_kwargs, type_names)

--- a/forge/workflows/allegro_utils/custom_stats.py
+++ b/forge/workflows/allegro_utils/custom_stats.py
@@ -21,36 +21,56 @@ class Quantile(Metric):
     This metric accumulates all data points and computes the exact quantile
     upon `compute()`.
 
+    To avoid performance degradation from concatenating a large number of
+    tensors, this implementation uses a buffering strategy. Tensors are
+    first collected in a temporary list (`_buffer`) and then concatenated
+    into a larger tensor once the buffer size exceeds a threshold. This
+    keeps the main `data` list short.
+
     Args:
         q (float): The quantile to compute (must be between 0.0 and 1.0).
+        buffer_size (int): The number of tensors to buffer before concatenating.
         **kwargs: Additional keyword arguments for the torchmetrics.Metric class.
     """
     full_state_update: bool = False
 
-    def __init__(self, q: float, **kwargs):
+    def __init__(self, q: float, buffer_size: int = 100, **kwargs):
         super().__init__(**kwargs)
         if not 0.0 <= q <= 1.0:
             raise ValueError(f"Quantile `q` must be between 0 and 1, but got {q}")
         self.q = q
+        self.buffer_size = buffer_size
         # "sum" for lists is concatenation. This is the correct way for this state.
         self.add_state("data", default=[], dist_reduce_fx="sum")
+        self._buffer: List[torch.Tensor] = []
 
     def update(self, data: torch.Tensor) -> None:
-        """Append data to the state tensor."""
+        """Append data to the internal buffer and consolidate if full."""
         if data.numel() > 0:
-            # Move to CPU to prevent device mismatches during DDP sync
-            self.data.append(data.flatten().cpu())
+            self._buffer.append(data.flatten().cpu())
+            if len(self._buffer) >= self.buffer_size:
+                self._consolidate_buffer()
+
+    def _consolidate_buffer(self):
+        if not self._buffer:
+            return
+        # Move buffered tensors to the main data state
+        self.data.append(torch.cat(self._buffer))
+        self._buffer.clear()
 
     def compute(self) -> torch.Tensor:
         """Compute the quantile of all collected data."""
+        # Ensure any remaining tensors in the buffer are included
+        self._consolidate_buffer()
+        
         if not self.data:
             return torch.tensor(float('nan'))
 
         data_cat = torch.cat(self.data)
-        
+
         if data_cat.numel() == 0:
             return torch.tensor(float('nan'))
-            
+
         return torch.quantile(data_cat.to(torch.float32), self.q)
 
     def __str__(self) -> str:

--- a/forge/workflows/allegro_utils/custom_stats.py
+++ b/forge/workflows/allegro_utils/custom_stats.py
@@ -5,7 +5,10 @@ from nequip.data import AtomicDataDict
 from nequip.data.modifier import BaseModifier, PerAtomModifier, NumNeighbors
 from nequip.data.stats import Mean, RootMeanSquare, StandardDeviation, _MeanX
 from nequip.data.stats_manager import DataStatisticsManager
+from nequip.train.metrics import StratifiedHuberForceLoss
 from nequip.utils.logger import RankedLogger
+from tqdm.auto import tqdm
+import sys
 
 
 logger = RankedLogger(__name__, rank_zero_only=True)
@@ -28,20 +31,26 @@ class Quantile(Metric):
         if not 0.0 <= q <= 1.0:
             raise ValueError(f"Quantile `q` must be between 0 and 1, but got {q}")
         self.q = q
-        self.add_state("data", default=torch.tensor([]), dist_reduce_fx="cat")
+        # "sum" for lists is concatenation. This is the correct way for this state.
+        self.add_state("data", default=[], dist_reduce_fx="sum")
 
     def update(self, data: torch.Tensor) -> None:
         """Append data to the state tensor."""
         if data.numel() > 0:
-            # Ensure data is on the same device as the state tensor before concatenating
-            self.data = torch.cat([self.data, data.flatten().to(self.data.device)])
+            # Move to CPU to prevent device mismatches during DDP sync
+            self.data.append(data.flatten().cpu())
 
     def compute(self) -> torch.Tensor:
         """Compute the quantile of all collected data."""
-        if self.data.numel() == 0:
+        if not self.data:
+            return torch.tensor(float('nan'))
+
+        data_cat = torch.cat(self.data)
+        
+        if data_cat.numel() == 0:
             return torch.tensor(float('nan'))
             
-        return torch.quantile(self.data.to(torch.float32), self.q)
+        return torch.quantile(data_cat.to(torch.float32), self.q)
 
     def __str__(self) -> str:
         return f"q_{self.q}"
@@ -52,9 +61,29 @@ class ForceMagnitude(BaseModifier):
     def __init__(self, field: str = AtomicDataDict.FORCE_KEY):
         super().__init__(field=field)
 
-    def forward(self, data: AtomicDataDict.Type) -> torch.Tensor:
-        forces = super().forward(data)
-        return torch.linalg.norm(forces, dim=-1)
+    def forward(self, forces: torch.Tensor) -> torch.Tensor:
+        """Operates on the `forces` tensor directly.
+        
+        The `forces` argument is `data[self.field]`, which is automatically
+        extracted by the `BaseModifier.__call__` method since `self.field`
+        is set in `__init__`.
+        """
+        # --- Final Debugging Step ---
+        if torch.any(torch.isnan(forces)):
+            print(f"!!! DEBUG ForceMagnitude: NaN values found in input `forces` tensor!", file=sys.stderr)
+        if torch.any(torch.isinf(forces)):
+            print(f"!!! DEBUG ForceMagnitude: Inf values found in input `forces` tensor!", file=sys.stderr)
+        # --- End Final Debugging Step ---
+        
+        magnitudes = torch.linalg.norm(forces, dim=-1)
+        if torch.any(magnitudes < 0):
+            print(f"!!! DEBUG ForceMagnitude: Negative values found in input `forces` tensor!", file=sys.stderr)
+        # Replace any potential NaNs from zero-vectors with 0.0
+        magnitudes = torch.nan_to_num(magnitudes, nan=0.0)
+        return magnitudes
+
+    def _func(self, data: AtomicDataDict.Type) -> torch.Tensor:
+        return self.forward(data[self.field])
 
     def __str__(self) -> str:
         return "force_magnitude"
@@ -74,7 +103,7 @@ def ExtendedDataStatisticsManager(
     metrics = [
         # Common stats
         {"name": "num_neighbors_mean", "field": NumNeighbors(), "metric": Mean()},
-        {"name": "per_atom_energy_mean", "field": PerAtomModifier(AtomicDataDict.TOTAL_ENERGY_KEY), "metric": Mean()},
+        {"name": "per_atom_energy_mean", "field": PerAtomModifier(field=AtomicDataDict.TOTAL_ENERGY_KEY), "metric": Mean()},
         {"name": "forces_rms", "field": AtomicDataDict.FORCE_KEY, "metric": RootMeanSquare()},
         {"name": "per_type_forces_rms", "field": AtomicDataDict.FORCE_KEY, "metric": RootMeanSquare(), "per_type": True},
         # Extended stats for loss parameters
@@ -138,5 +167,28 @@ def ExtendedDataStatisticsManager(
         return stats
 
     base_manager.compute = extended_compute.__get__(base_manager, DataStatisticsManager)
+
+    # Monkey-patch the get_statistics method to add tqdm progress bar
+    def extended_get_statistics(self, data_source: Iterable[AtomicDataDict.Type]):
+        """A get_statistics method with a tqdm progress bar."""
+        if isinstance(data_source, dict):
+            raise TypeError(
+                f"The data source passed to get_statistics was a dictionary, not a DataLoader or other iterable. "
+                f"It seems you passed dataloader keyword arguments instead of an instantiated dataloader. "
+                f"Received dict with keys: {list(data_source.keys())}"
+            )
+            
+        pbar = tqdm(
+            data_source,
+            desc="Calculating statistics",
+            total=len(data_source) if hasattr(data_source, '__len__') else None,
+            disable=getattr(self, 'rank', 0) != 0 # Show progress bar only on rank 0
+        )
+        # The caller of get_statistics is responsible for calling .reset()
+        for data in pbar:
+            self(data) # This calls the forward method
+        return self.compute()
+
+    base_manager.get_statistics = extended_get_statistics.__get__(base_manager, DataStatisticsManager)
 
     return base_manager 

--- a/forge/workflows/allegro_utils/custom_stats.py
+++ b/forge/workflows/allegro_utils/custom_stats.py
@@ -220,8 +220,12 @@ def ExtendedDataStatisticsManager(
     # Monkey-patch the get_statistics method to add tqdm progress bar
     def extended_get_statistics(self, data_source: Iterable[AtomicDataDict.Type]):
         """A get_statistics method that runs only on rank 0 in a distributed setting."""
-        rank = getattr(self, 'rank', 0)
-        world_size = getattr(self, 'world_size', 1)
+        if dist.is_available() and dist.is_initialized():
+            rank = dist.get_rank()
+            world_size = dist.get_world_size()
+        else:
+            rank = 0
+            world_size = 1
 
         stats = None
         # Only rank 0 does the actual computation

--- a/forge/workflows/allegro_utils/custom_stats.py
+++ b/forge/workflows/allegro_utils/custom_stats.py
@@ -1,6 +1,7 @@
 from typing import List, Dict, Union, Callable, Iterable, Optional
 import os
 import torch
+import torch.distributed as dist
 from torchmetrics import Metric
 from nequip.data import AtomicDataDict
 from nequip.data.modifier import BaseModifier, PerAtomModifier, NumNeighbors
@@ -125,6 +126,13 @@ def ExtendedDataStatisticsManager(
     - Derived values for `focal_beta` and `stratified_huber_deltas`.
     """
     # --- Performance optimizations for statistics calculation ---
+    if 'batch_size' not in dataloader_kwargs:
+        # Statistics calculation is often I/O or CPU bound, not GPU memory bound,
+        # so a larger batch size can significantly speed up data loading.
+        stats_batch_size = 32  # A reasonable default
+        dataloader_kwargs['batch_size'] = stats_batch_size
+        logger.info(f"Automatically setting batch_size for statistics to {stats_batch_size} for faster calculation.")
+
     if 'num_workers' not in dataloader_kwargs:
         try:
             # Default to half the available CPU cores, capped at 8.
@@ -211,24 +219,37 @@ def ExtendedDataStatisticsManager(
 
     # Monkey-patch the get_statistics method to add tqdm progress bar
     def extended_get_statistics(self, data_source: Iterable[AtomicDataDict.Type]):
-        """A get_statistics method with a tqdm progress bar."""
-        if isinstance(data_source, dict):
-            raise TypeError(
-                f"The data source passed to get_statistics was a dictionary, not a DataLoader or other iterable. "
-                f"It seems you passed dataloader keyword arguments instead of an instantiated dataloader. "
-                f"Received dict with keys: {list(data_source.keys())}"
+        """A get_statistics method that runs only on rank 0 in a distributed setting."""
+        rank = getattr(self, 'rank', 0)
+        world_size = getattr(self, 'world_size', 1)
+
+        stats = None
+        # Only rank 0 does the actual computation
+        if rank == 0:
+            if isinstance(data_source, dict):
+                raise TypeError(
+                    f"The data source passed to get_statistics was a dictionary, not a DataLoader or other iterable. "
+                    f"It seems you passed dataloader keyword arguments instead of an instantiated dataloader. "
+                    f"Received dict with keys: {list(data_source.keys())}"
+                )
+                
+            pbar = tqdm(
+                data_source,
+                desc="Calculating statistics",
+                total=len(data_source) if hasattr(data_source, '__len__') else None,
             )
-            
-        pbar = tqdm(
-            data_source,
-            desc="Calculating statistics",
-            total=len(data_source) if hasattr(data_source, '__len__') else None,
-            disable=getattr(self, 'rank', 0) != 0 # Show progress bar only on rank 0
-        )
-        # The caller of get_statistics is responsible for calling .reset()
-        for data in pbar:
-            self(data) # This calls the forward method
-        return self.compute()
+            # The caller of get_statistics is responsible for calling .reset()
+            for data in pbar:
+                self(data) # This calls the forward method
+            stats = self.compute()
+
+        # In a distributed setting, broadcast the stats from rank 0 to all other ranks.
+        if world_size > 1:
+            stats_list = [stats]  # broadcast_object_list works on a list
+            dist.broadcast_object_list(stats_list, src=0)
+            stats = stats_list[0]
+        
+        return stats
 
     base_manager.get_statistics = extended_get_statistics.__get__(base_manager, DataStatisticsManager)
 

--- a/forge/workflows/allegro_utils/custom_stats.py
+++ b/forge/workflows/allegro_utils/custom_stats.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Union, Callable, Iterable, Optional
+import os
 import torch
 from torchmetrics import Metric
 from nequip.data import AtomicDataDict
@@ -100,6 +101,23 @@ def ExtendedDataStatisticsManager(
     - Quantiles of force magnitudes (q10, q50, q90, q95) for Huber/Focal loss params.
     - Derived values for `focal_beta` and `stratified_huber_deltas`.
     """
+    # --- Performance optimizations for statistics calculation ---
+    if 'num_workers' not in dataloader_kwargs:
+        try:
+            # Default to half the available CPU cores, capped at 8.
+            num_cpus = os.cpu_count()
+            num_workers = min(num_cpus // 2 if num_cpus else 0, 8)
+            if num_workers > 0:
+                dataloader_kwargs['num_workers'] = num_workers
+                logger.info(f"Automatically setting num_workers for statistics to {num_workers} for faster data loading.")
+        except NotImplementedError:
+            logger.warning("Could not determine the number of CPUs. Statistics calculation might be slow.")
+
+    if 'pin_memory' not in dataloader_kwargs and torch.cuda.is_available():
+        dataloader_kwargs['pin_memory'] = True
+        logger.info("Setting pin_memory=True for statistics calculation to speed up CPU-GPU data transfer.")
+    # --- End of performance optimizations ---
+    
     metrics = [
         # Common stats
         {"name": "num_neighbors_mean", "field": NumNeighbors(), "metric": Mean()},

--- a/forge/workflows/allegro_utils/custom_stats.py
+++ b/forge/workflows/allegro_utils/custom_stats.py
@@ -1,0 +1,155 @@
+from typing import List, Dict, Union, Callable, Iterable, Optional
+import torch
+from torchmetrics import Metric
+from nequip.data import AtomicDataDict
+from nequip.data.modifier import BaseModifier, PerAtomModifier, NumNeighbors
+from nequip.data.stats import Mean, RootMeanSquare, StandardDeviation, _MeanX
+from nequip.data.dataloader import Collater
+from nequip.utils.logger import RankedLogger
+from nequip.data.stats import DataStatisticsManager
+
+
+logger = RankedLogger(__name__, rank_zero_only=True)
+
+
+class Quantile(Metric):
+    """Computes the q-th quantile of a stream of data.
+
+    This metric accumulates all data points and computes the exact quantile
+    upon `compute()`.
+
+    Args:
+        q (float): The quantile to compute (must be between 0.0 and 1.0).
+        **kwargs: Additional keyword arguments for the torchmetrics.Metric class.
+    """
+    full_state_update: bool = False
+
+    def __init__(self, q: float, **kwargs):
+        super().__init__(**kwargs)
+        if not 0.0 <= q <= 1.0:
+            raise ValueError(f"Quantile `q` must be between 0 and 1, but got {q}")
+        self.q = q
+        self.add_state("data", default=[], dist_reduce_fx="cat")
+
+    def update(self, data: torch.Tensor) -> None:
+        """Append data to the state."""
+        if data.numel() > 0:
+            self.data.append(data.flatten())
+
+    def compute(self) -> torch.Tensor:
+        """Compute the quantile of all collected data."""
+        if not self.data:
+            return torch.tensor(float('nan'))
+        
+        # On DDP, self.data will be a list of lists of tensors, so flatten it
+        if any(isinstance(i, list) for i in self.data):
+             all_data = [item for sublist in self.data for item in sublist]
+        else:
+            all_data = self.data
+        
+        if not all_data:
+            return torch.tensor(float('nan'))
+            
+        data_cat = torch.cat(all_data)
+        if data_cat.numel() == 0:
+            return torch.tensor(float('nan'))
+        return torch.quantile(data_cat.to(torch.float32), self.q)
+
+    def __str__(self) -> str:
+        return f"q_{self.q}"
+
+
+class ForceMagnitude(BaseModifier):
+    """A modifier to compute the magnitude of force vectors."""
+    def __init__(self, field: str = AtomicDataDict.FORCE_KEY):
+        super().__init__(field=field)
+        self.type = "node"
+
+    def forward(self, data: AtomicDataDict.Type) -> torch.Tensor:
+        forces = super().forward(data)
+        return torch.linalg.norm(forces, dim=-1)
+
+    def __str__(self) -> str:
+        return "force_magnitude"
+
+
+def ExtendedDataStatisticsManager(
+    dataloader_kwargs: Dict = {},
+    type_names: List[str] = None,
+):
+    """A DataStatisticsManager that includes extended statistics for custom losses.
+    
+    This manager computes:
+    - Standard statistics from CommonDataStatisticsManager.
+    - Quantiles of force magnitudes (q10, q50, q90, q95) for Huber/Focal loss params.
+    - Derived values for `focal_beta` and `stratified_huber_deltas`.
+    """
+    metrics = [
+        # Common stats
+        {"name": "num_neighbors_mean", "field": NumNeighbors(), "metric": Mean()},
+        {"name": "per_atom_energy_mean", "field": PerAtomModifier(AtomicDataDict.TOTAL_ENERGY_KEY), "metric": Mean()},
+        {"name": "forces_rms", "field": AtomicDataDict.FORCE_KEY, "metric": RootMeanSquare()},
+        {"name": "per_type_forces_rms", "field": AtomicDataDict.FORCE_KEY, "metric": RootMeanSquare(), "per_type": True},
+        # Extended stats for loss parameters
+        {"name": "force_magnitude_q10", "field": ForceMagnitude(), "metric": Quantile(0.10)},
+        {"name": "force_magnitude_q50", "field": ForceMagnitude(), "metric": Quantile(0.50)},
+        {"name": "force_magnitude_q90", "field": ForceMagnitude(), "metric": Quantile(0.90)},
+        {"name": "force_magnitude_q95", "field": ForceMagnitude(), "metric": Quantile(0.95)},
+    ]
+    
+    base_manager = DataStatisticsManager(metrics, dataloader_kwargs, type_names)
+
+    # Monkey-patch the compute method to add derived statistics
+    original_compute = base_manager.compute
+    
+    def extended_compute(self):
+        # Call original compute to get base stats
+        stats = original_compute()
+        logger.info("Computing extended statistics for loss functions...")
+
+        # --- Compute FocalMSELoss beta ---
+        if 'forces_rms' in stats:
+            forces_rms = stats['forces_rms']
+            if forces_rms > 1e-6:
+                focal_beta = 1.0 / forces_rms
+                stats['focal_beta'] = focal_beta
+                logger.info(f"focal_beta: {focal_beta:.4f} (from 1/forces_rms)")
+            else:
+                logger.warning("forces_rms is very small, skipping focal_beta calculation.")
+
+        # --- Compute Huber delta (from q95) ---
+        if 'force_magnitude_q95' in stats:
+            huber_delta = stats['force_magnitude_q95']
+            stats['huber_delta'] = huber_delta
+            logger.info(f"huber_delta: {huber_delta:.4f} (from force_magnitude_q95)")
+
+        # --- Compute Stratified Huber deltas ---
+        q10 = stats.get('force_magnitude_q10')
+        q50 = stats.get('force_magnitude_q50')
+        q90 = stats.get('force_magnitude_q90')
+        
+        if all(k is not None for k in [q10, q50, q90]):
+            # Boundaries for stratified loss
+            boundaries = [q10, q50, q90]
+            stats['stratified_huber_boundaries'] = boundaries
+            logger.info(f"stratified_huber_boundaries: {[f'{b:.4f}' for b in boundaries]}")
+            
+            # Deltas for each bin
+            # For the first bin (0, p10), the lower bound is 0, which would give a
+            # delta of 0. This is ill-defined for Huber loss. We'll use 0.1 * p10
+            # for the first bin as a sensible default.
+            delta1 = 0.1 * q10
+            delta2 = 0.1 * q10
+            delta3 = 0.1 * q50
+            delta4 = 0.1 * q90
+            deltas = [delta1, delta2, delta3, delta4]
+            stats['stratified_huber_deltas'] = deltas
+            logger.info(f"stratified_huber_deltas: {[f'{d:.4f}' for d in deltas]}")
+        else:
+            logger.warning("Could not compute stratified huber deltas because one of the required quantiles (q10, q50, q90) is missing.")
+
+        return stats
+
+    base_manager.compute = extended_compute.__get__(base_manager, DataStatisticsManager)
+
+    return base_manager 

--- a/forge/workflows/db_to_allegro.py
+++ b/forge/workflows/db_to_allegro.py
@@ -282,14 +282,13 @@ def _build_loss_metrics(loss_coeffs: Dict[str, Any]) -> List[Dict[str, Any]]:
             raise ValueError(f"Unsupported loss metric '{metric_name}'. Must be one of {list(METRIC_MAP.keys())}")
         
         # Handle auto-parameterization
-        if metric_params:
-            if metric_name == "huber" and metric_params.get("delta") == "auto":
-                metric_params["delta"] = "${training_data_stats:huber_delta}"
-            if metric_name == "focal_mse" and metric_params.get("beta") == "auto":
-                metric_params["beta"] = "${training_data_stats:focal_beta}"
-            if metric_name == "auto_stratified_huber":
-                metric_params["boundaries"] = "${training_data_stats:stratified_huber_boundaries}"
-                metric_params["deltas"] = "${training_data_stats:stratified_huber_deltas}"
+        if metric_name == "huber" and metric_params.get("delta") == "auto":
+            metric_params["delta"] = "${training_data_stats:huber_delta}"
+        if metric_name == "focal_mse" and metric_params.get("beta") == "auto":
+            metric_params["beta"] = "${training_data_stats:focal_beta}"
+        if metric_name == "auto_stratified_huber":
+            metric_params["boundaries"] = "${training_data_stats:stratified_huber_boundaries}"
+            metric_params["deltas"] = "${training_data_stats:stratified_huber_deltas}"
 
         metric_target = METRIC_MAP[metric_name]
 

--- a/forge/workflows/db_to_allegro.py
+++ b/forge/workflows/db_to_allegro.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # --- Import custom components for type hinting and path resolution ---
 from forge.workflows.allegro_utils.callbacks import CurriculumCallback, GradNormCallback
 from forge.workflows.allegro_utils.custom_metrics import (
-    FocalMSELoss, TailMSE, TailHuberLoss, ForceAngleLoss, StressShearMAE, StressAngleLoss
+    FocalMSELoss, TailMSE, TailHuberLoss, ForceAngleLoss, StressShearMAE, StressAngleLoss, AutoStratifiedHuberLoss
 )
 from forge.workflows.allegro_utils.samplers import RareWeightedSampler
 from forge.workflows.allegro_utils.data_v3 import CustomSamplingASEDataModuleV3
@@ -47,6 +47,7 @@ METRIC_MAP = {
     "force_angle": "forge.workflows.allegro_utils.custom_metrics.ForceAngleLoss",
     "stress_shear_mae": "forge.workflows.allegro_utils.custom_metrics.StressShearMAE",
     "stress_angle": "forge.workflows.allegro_utils.custom_metrics.StressAngleLoss",
+    "auto_stratified_huber": "forge.workflows.allegro_utils.custom_metrics.AutoStratifiedHuberLoss",
 }
 
 def _extract_chemical_symbols(
@@ -115,6 +116,7 @@ def _prepare_data_for_allegro(
     seed: int,
     num_structures: Optional[int],
     structure_ids: Optional[List[int]],
+    val_b_ids: Optional[List[int]],
     train_ratio: Optional[float],
     val_ratio: Optional[float],
     test_ratio: Optional[float],
@@ -144,6 +146,8 @@ def _prepare_data_for_allegro(
             the database in standalone mode.
         structure_ids (Optional[List[int]]): Specific structure IDs to use in
             standalone mode.
+        val_b_ids (Optional[List[int]]): A specific list of structure IDs to use for
+            a second, 'hard' validation set (val_b).
         train_ratio (Optional[float]): The fraction of data for the training set.
         val_ratio (Optional[float]): The fraction of data for the validation set.
         test_ratio (Optional[float]): The fraction of data for the test set.
@@ -151,7 +155,7 @@ def _prepare_data_for_allegro(
     Returns:
         Dict[str, Any]: A dictionary containing:
             - "train_path": Path to the training data file.
-            - "val_path": Path to the validation data file.
+            - "val_path": Path(s) to the validation data file(s).
             - "test_path": Path to the test data file.
             - "chemical_symbols": A list of unique, sorted chemical symbols.
             - "structure_splits": A dict with the train/val/test structure IDs.
@@ -216,6 +220,13 @@ def _prepare_data_for_allegro(
             random.seed(seed)
             final_ids = random.sample(all_db_ids, num_to_sample)
         
+        val_paths = [f"data/{job_name}_val.xyz"] # Val-A, will be created by _prepare_structure_splits
+        if val_b_ids:
+            logger.info(f"Using {len(val_b_ids)} structures for Val-B set.")
+            _save_structures_to_xyz(db_manager, val_b_ids, job_data_dir / f"{job_name}_val_b.xyz")
+            final_ids = [sid for sid in final_ids if sid not in val_b_ids]
+            val_paths.append(f"data/{job_name}_val_b.xyz")
+
         if not final_ids:
             raise ValueError("No structures selected for standalone run.")
 
@@ -228,7 +239,7 @@ def _prepare_data_for_allegro(
 
         return {
             "train_path": f"data/{job_name}_train.xyz",
-            "val_path": f"data/{job_name}_val.xyz",
+            "val_path": val_paths,
             "test_path": f"data/{job_name}_test.xyz",
             "chemical_symbols": chemical_symbols,
             "structure_splits": structure_splits,
@@ -270,6 +281,16 @@ def _build_loss_metrics(loss_coeffs: Dict[str, Any]) -> List[Dict[str, Any]]:
         if metric_name not in METRIC_MAP:
             raise ValueError(f"Unsupported loss metric '{metric_name}'. Must be one of {list(METRIC_MAP.keys())}")
         
+        # Handle auto-parameterization
+        if metric_params:
+            if metric_name == "huber" and metric_params.get("delta") == "auto":
+                metric_params["delta"] = "${training_data_stats:huber_delta}"
+            if metric_name == "focal_mse" and metric_params.get("beta") == "auto":
+                metric_params["beta"] = "${training_data_stats:focal_beta}"
+            if metric_name == "auto_stratified_huber":
+                metric_params["boundaries"] = "${training_data_stats:stratified_huber_boundaries}"
+                metric_params["deltas"] = "${training_data_stats:stratified_huber_deltas}"
+
         metric_target = METRIC_MAP[metric_name]
 
         # Handle energy field modifications
@@ -352,7 +373,7 @@ def _build_validation_metrics(
             
     return val_metrics
     
-def _update_trainer_callbacks(config: Dict[str, Any], job_name: str, checkpoint_monitor_key: str, loss_schedule: Optional[Dict[int, Dict[str, float]]]):
+def _update_trainer_callbacks(config: Dict[str, Any], job_name: str, checkpoint_monitor_key: str, loss_schedule: Optional[Dict[int, Dict[str, float]]], use_soft_adapt: bool = False, soft_adapt_params: Optional[Dict[str, Any]] = None):
     """Updates or adds the necessary training callbacks to the configuration.
 
     This function ensures that the configuration's trainer section has the
@@ -368,9 +389,15 @@ def _update_trainer_callbacks(config: Dict[str, Any], job_name: str, checkpoint_
             the best model checkpoint.
         loss_schedule (Optional[Dict[int, Dict[str, float]]]): An optional schedule
             for the LossCoefficientScheduler.
+        use_soft_adapt (bool): Whether to use the SoftAdapt callback.
+        soft_adapt_params (Optional[Dict[str, Any]]): Parameters for SoftAdapt.
     """
     if 'callbacks' not in config.get('trainer', {}):
         config.setdefault('trainer', {})['callbacks'] = []
+
+    # Ensure LossCoefficientScheduler and SoftAdapt are not used together
+    if loss_schedule and use_soft_adapt:
+        raise ValueError("LossCoefficientScheduler and SoftAdapt cannot be used simultaneously.")
 
     checkpoint_callback = next((cb for cb in config['trainer']['callbacks'] if 'ModelCheckpoint' in cb.get('_target_', '')), None)
     if checkpoint_callback:
@@ -388,6 +415,16 @@ def _update_trainer_callbacks(config: Dict[str, Any], job_name: str, checkpoint_
             "_target_": "nequip.train.callbacks.LossCoefficientScheduler", "schedule": loss_schedule
         })
     
+    # Add SoftAdapt callback if requested
+    config['trainer']['callbacks'] = [cb for cb in config['trainer']['callbacks'] if 'SoftAdapt' not in cb.get('_target_', '')]
+    if use_soft_adapt:
+        if not soft_adapt_params:
+            soft_adapt_params = {}
+        config['trainer']['callbacks'].append({
+            "_target_": "nequip.train.callbacks.SoftAdapt",
+            **soft_adapt_params
+        })
+
     if not any('LearningRateMonitor' in cb.get('_target_', '') for cb in config['trainer']['callbacks']):
         config['trainer']['callbacks'].append({"_target_": "lightning.pytorch.callbacks.LearningRateMonitor", "logging_interval": "epoch"})
     if not any('LossCoefficientMonitor' in cb.get('_target_', '') for cb in config['trainer']['callbacks']):
@@ -451,6 +488,10 @@ def _build_allegro_config(
     config['data']['val_file_path'] = data_paths["val_path"]
     config['data']['test_file_path'] = data_paths["test_path"]
 
+    # Add val_b if it exists
+    if data_paths.get("val_b_path"):
+        config['data']['val_b_file_path'] = data_paths["val_b_path"]
+
     # Update hyperparameters from kwargs
     config['training_module']['model']['r_max'] = kwargs['r_max']
     config['cutoff_radius'] = kwargs['r_max']
@@ -498,7 +539,10 @@ def _build_allegro_config(
         }
     
     _update_trainer_callbacks(
-        config, job_name, kwargs['checkpoint_monitor_key'], kwargs.get('loss_schedule')
+        config, job_name, kwargs['checkpoint_monitor_key'], 
+        kwargs.get('loss_schedule'),
+        kwargs.get('use_soft_adapt', False),
+        kwargs.get('soft_adapt_params')
     )
 
     if kwargs.get('extra_trainer_params'):
@@ -519,6 +563,7 @@ def prepare_allegro_job(
     seed: int = 0,
     num_structures: Optional[int] = None,
     structure_ids: Optional[List[int]] = None,
+    val_b_ids: Optional[List[int]] = None,
     train_ratio: Optional[float] = 0.8,
     val_ratio: Optional[float] = 0.1,
     test_ratio: Optional[float] = 0.1,
@@ -530,6 +575,8 @@ def prepare_allegro_job(
     include_default_val_metrics: bool = True,
     extra_val_metrics: Optional[List[Dict[str, Any]]] = None,
     extra_trainer_params: Optional[Dict[str, Any]] = None,
+    use_soft_adapt: bool = False,
+    soft_adapt_params: Optional[Dict[str, Any]] = None,
     checkpoint_monitor_key: str = "val0_epoch/stress_rmse",
     # Allegro Hyperparameters
     max_epochs: int = 400,
@@ -574,6 +621,7 @@ def prepare_allegro_job(
         seed (int): Random seed for reproducibility.
         num_structures (Optional[int]): Number of structures to sample from the DB.
         structure_ids (Optional[List[int]]): Specific list of structure IDs to use.
+        val_b_ids (Optional[List[int]]): IDs for the 'hard' validation set.
         train_ratio (Optional[float]): Fraction of data for the training set.
         val_ratio (Optional[float]): Fraction of data for the validation set.
         test_ratio (Optional[float]): Fraction of data for the test set.
@@ -586,6 +634,8 @@ def prepare_allegro_job(
         extra_val_metrics (Optional[List[Dict[str, Any]]]): Additional validation metrics.
         extra_trainer_params (Optional[Dict[str, Any]]): Extra parameters for the
             PyTorch Lightning Trainer.
+        use_soft_adapt (bool): Whether to use the SoftAdapt callback.
+        soft_adapt_params (Optional[Dict[str, Any]]): Parameters for SoftAdapt.
         checkpoint_monitor_key (str): Metric to monitor for saving checkpoints.
         max_epochs (int): Maximum number of training epochs.
         batch_size (int): Batch size for training and validation.
@@ -614,6 +664,7 @@ def prepare_allegro_job(
         data_train_path=data_train_path, data_val_path=data_val_path,
         data_test_path=data_test_path, chemical_symbols_list=chemical_symbols_list,
         seed=seed, num_structures=num_structures, structure_ids=structure_ids,
+        val_b_ids=val_b_ids,
         train_ratio=train_ratio, val_ratio=val_ratio, test_ratio=test_ratio,
     )
     
@@ -623,6 +674,7 @@ def prepare_allegro_job(
         'data_train_path': data_train_path, 'data_val_path': data_val_path,
         'data_test_path': data_test_path, 'chemical_symbols_list': chemical_symbols_list,
         'num_structures': num_structures, 'structure_ids': structure_ids,
+        'val_b_ids': val_b_ids,
         'train_ratio': train_ratio, 'val_ratio': val_ratio, 'test_ratio': test_ratio,
         'loss_coeffs': loss_coeffs,
         'loss_schedule': loss_schedule, 'sampler': sampler,
@@ -630,6 +682,8 @@ def prepare_allegro_job(
         'include_default_val_metrics': include_default_val_metrics,
         'extra_val_metrics': extra_val_metrics,
         'extra_trainer_params': extra_trainer_params,
+        'use_soft_adapt': use_soft_adapt,
+        'soft_adapt_params': soft_adapt_params,
         'checkpoint_monitor_key': checkpoint_monitor_key, 'max_epochs': max_epochs,
         'batch_size': batch_size, 'wandb_project': wandb_project,
         'lr': lr, 'r_max': r_max, 'l_max': l_max,

--- a/scratch/scripts/debug_custom_stats.py
+++ b/scratch/scripts/debug_custom_stats.py
@@ -1,0 +1,85 @@
+# scratch/scripts/debug_custom_stats.py
+import logging
+from pathlib import Path
+import torch
+from forge.core.database import DatabaseManager
+from forge.workflows.allegro_utils.custom_stats import ExtendedDataStatisticsManager
+from nequip.data.datamodule import ASEDataModule
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def main():
+    """
+    A minimal script to test and debug the ExtendedDataStatisticsManager.
+    """
+    chemical_symbols = ["Ti", "V", "Cr", "Zr", "W"]
+    # --- 1. Get a small subset of data ---
+    logger.info("Initializing database to fetch a small test dataset...")
+    with DatabaseManager() as db_manager:
+        all_ids = db_manager.get_all_structure_ids()
+        if len(all_ids) > 1000:
+            test_ids = all_ids[:1000]
+            logger.info(f"Using the first 1000 structures for the test.")
+        else:
+            test_ids = all_ids
+            logger.info(f"Using all {len(all_ids)} available structures for the test.")
+
+    if not test_ids:
+        logger.error("No structures found in the database. Exiting.")
+        return
+
+    # --- 2. Create a temporary data file ---
+    temp_dir = Path("./temp_stats_debug")
+    temp_dir.mkdir(exist_ok=True)
+    train_xyz_path = temp_dir / "train.xyz"
+    val_xyz_path = temp_dir / "val.xyz"
+
+    logger.info(f"Saving {len(test_ids)} structures to temporary files...")
+    with DatabaseManager() as db_manager:
+        atoms_list = db_manager.get_batch_atoms_with_calculation(test_ids)
+        # Split the list for train/val
+        train_atoms = atoms_list[:800]
+        val_atoms = atoms_list[800:]
+        from ase.io import write
+        write(train_xyz_path, train_atoms, format='extxyz')
+        write(val_xyz_path, val_atoms, format='extxyz')
+
+    # --- 3. Instantiate the DataStatisticsManager ---
+    logger.info("Instantiating ExtendedDataStatisticsManager...")
+    stats_manager = ExtendedDataStatisticsManager(
+        dataloader_kwargs={'batch_size': 32, 'num_workers': 0},
+        type_names=chemical_symbols
+    )
+
+    # --- 4. Create a DataLoader ---
+    # We use nequip's ASEDataModule to create a dataset and dataloader
+    # This mimics how it's used in a real training run.
+    data_module = ASEDataModule(
+        train_file_path=str(train_xyz_path),
+        val_file_path=str(val_xyz_path),
+        seed=42
+    )
+    data_module.setup(stage="fit")
+    dataloader = data_module.train_dataloader()
+    
+    # --- 5. Run the Statistics Computation ---
+    logger.info("Calculating statistics... (this may take a moment)")
+    stats_manager.reset() # Ensure state is clean
+    final_stats = stats_manager.get_statistics(dataloader)
+
+    # --- 6. Print the results ---
+    logger.info("-" * 80)
+    logger.info("Custom statistics calculation complete. Final Results:")
+    for key, value in final_stats.items():
+        logger.info(f"  {key}: {value}")
+    logger.info("-" * 80)
+    
+    # Clean up temporary file
+    import shutil
+    shutil.rmtree(temp_dir)
+    logger.info(f"Cleaned up temporary directory: {temp_dir}")
+
+if __name__ == "__main__":
+    main() 

--- a/scratch/scripts/debug_custom_stats_v2.py
+++ b/scratch/scripts/debug_custom_stats_v2.py
@@ -24,13 +24,13 @@ def main():
     with DatabaseManager() as db_manager:
         # Get enough structures for train, val_a, and val_b
         all_ids = db_manager.find_structures_by_metadata({'generation': 0}, operator='>=')
-        if len(all_ids) < 70:
+        if len(all_ids) < 2500:
             logger.error(f"Not enough structures found in DB ({len(all_ids)}). Need at least 70 for this test. Exiting.")
             return
 
         random.shuffle(all_ids)
-        val_b_ids = all_ids[:20]
-        structure_ids_for_split = all_ids[20:70] # Use next 50 for train/val_a
+        val_b_ids = all_ids[:250]
+        structure_ids_for_split = all_ids[250:2500] # Use next 50 for train/val_a
         logger.info(f"Using {len(structure_ids_for_split)} structures for train/val_a and {len(val_b_ids)} for val_b.")
 
         prepare_allegro_job(

--- a/scratch/scripts/debug_custom_stats_v2.py
+++ b/scratch/scripts/debug_custom_stats_v2.py
@@ -1,0 +1,97 @@
+# scratch/scripts/debug_custom_stats_v2.py
+import logging
+from pathlib import Path
+import yaml
+import random
+
+from forge.core.database import DatabaseManager
+from forge.workflows.db_to_allegro import prepare_allegro_job
+from hydra.utils import instantiate
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def main():
+    """Prepares an Allegro job and then programmatically runs the statistics calculation."""
+    experiment_name = "debug_stats_run"
+    job_name = "debug_job"
+    base_dir = Path(f"./{experiment_name}")
+    job_dir = base_dir / job_name
+
+    # --- 1. Prepare an Allegro job with multiple validation sets ---
+    logger.info(f"Preparing Allegro job '{job_name}' in {job_dir}...")
+    with DatabaseManager() as db_manager:
+        # Get enough structures for train, val_a, and val_b
+        all_ids = db_manager.find_structures_by_metadata({'generation': 0}, operator='>=')
+        if len(all_ids) < 70:
+            logger.error(f"Not enough structures found in DB ({len(all_ids)}). Need at least 70 for this test. Exiting.")
+            return
+
+        random.shuffle(all_ids)
+        val_b_ids = all_ids[:20]
+        structure_ids_for_split = all_ids[20:70] # Use next 50 for train/val_a
+        logger.info(f"Using {len(structure_ids_for_split)} structures for train/val_a and {len(val_b_ids)} for val_b.")
+
+        prepare_allegro_job(
+            db_manager=db_manager,
+            job_name=job_name,
+            job_dir=job_dir,
+            structure_ids=structure_ids_for_split,
+            val_b_ids=val_b_ids,
+            train_ratio=0.8, val_ratio=0.2, test_ratio=0.0, # Splits the main pool
+            loss_coeffs={"total_energy": {"coeff": 1.0, "metric": "mse"}}, # Simple loss
+            max_epochs=1, # Not training, just for config
+            r_max=5.0,
+        )
+    logger.info("Job preparation complete. Config.yaml created.")
+
+    # --- 2. Load the generated config and run statistics ---
+    config_path = job_dir / "config.yaml"
+    logger.info(f"Loading config from {config_path}")
+    
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    logger.info("Instantiating DataModule from config...")
+    data_module = instantiate(config['data'])
+    data_module.prepare_data()
+    data_module.setup("fit") # Use 'fit' to prepare train and val splits
+
+    # --- 3. Verify validation dataloaders ---
+    logger.info("Checking validation dataloaders...")
+    val_dataloaders = data_module.val_dataloader()
+    if isinstance(val_dataloaders, list):
+        logger.info(f"SUCCESS: Found {len(val_dataloaders)} validation dataloaders.")
+        for i, dl in enumerate(val_dataloaders):
+            logger.info(f"  - Val dataloader {i} has {len(dl.dataset)} samples.")
+    else:
+        logger.warning("Found only one validation dataloader, not a list as expected.")
+
+    # --- 4. The main test: Calculate statistics on the training set ---
+    logger.info("Getting training dataloader...")
+    train_dataloader = data_module.train_dataloader()
+    
+    # In NequIP, the DataStatisticsManager is an attribute of the DataModule
+    stats_manager = data_module.dataset_statistic_manager
+    logger.info(f"Using stats manager: {type(stats_manager)}")
+
+    logger.info("Resetting and calculating statistics...")
+    stats_manager.reset()
+    final_stats = stats_manager.get_statistics(train_dataloader)
+
+    logger.info("\n--- FINAL STATISTICS ---")
+    for key, value in final_stats.items():
+        if isinstance(value, dict):
+            logger.info(f"  {key}:")
+            for k, v in value.items():
+                logger.info(f"    {k}: {v:.4f}")
+        elif isinstance(value, list):
+             logger.info(f"  {key}: {[f'{v:.4f}' for v in value]}")
+        else:
+            logger.info(f"  {key}: {value:.4f}")
+    logger.info("------------------------")
+    logger.info("\nStatistics calculation successful.")
+
+if __name__ == "__main__":
+    main() 

--- a/scratch/scripts/run_allegro_loss_experiment.py
+++ b/scratch/scripts/run_allegro_loss_experiment.py
@@ -1,0 +1,123 @@
+# scratch/scripts/run_allegro_loss_experiment.py
+import logging
+import json
+from pathlib import Path
+from itertools import product
+import random
+
+from forge.core.database import DatabaseManager
+from forge.workflows.db_to_allegro import prepare_allegro_job
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def run_and_summarize(job_dir, **kwargs):
+    """Helper to run prepare_allegro_job and print a summary."""
+    # Check if data already exists
+    train_xyz_path = job_dir / "data" / f"{kwargs['job_name']}_train.xyz"
+    if train_xyz_path.exists():
+        logger.info(f"Data for job '{kwargs['job_name']}' already exists. Skipping data preparation.")
+        return
+
+    logger.info("-" * 80)
+    logger.info(f"Preparing job '{kwargs['job_name']}' in directory: {job_dir.resolve()}")
+    
+    # Use a fresh DB connection for each job preparation
+    with DatabaseManager() as db_manager:
+        try:
+            structure_splits = prepare_allegro_job(db_manager=db_manager, job_dir=job_dir, **kwargs)
+            
+            logger.info("\n  SUCCESS: Allegro job prepared.")
+            logger.info(f"  - Job Directory: {job_dir.resolve()}")
+            logger.info("  - Config file created: config.yaml")
+            if structure_splits:
+                for split_name, struct_ids in structure_splits.items():
+                    logger.info(f"    - {split_name}: {len(struct_ids)} structures")
+            
+            logger.info("\n  To run this training job, execute:")
+            logger.info(f"  cd {job_dir.resolve()}")
+            logger.info("  nequip-train config.yaml")
+            logger.info("-" * 80 + "\n")
+
+        except Exception as e:
+            logger.error(f"Failed to prepare job '{kwargs['job_name']}': {e}", exc_info=True)
+            logger.info("-" * 80 + "\n")
+
+
+def main():
+    """Main function to prepare a systematic Allegro training experiment for loss functions."""
+    logger.info("Initializing database connection...")
+    with DatabaseManager() as db_manager:
+        all_ids = db_manager.find_structures_by_metadata({'generation': 0}, operator='>=')
+        dimer_ids = db_manager.find_structures_by_metadata({'config_type': 'dimer'})
+        structure_ids = [sid for sid in all_ids if sid not in dimer_ids]
+        logger.info(f"Found {len(structure_ids)} structures for the experiment.")
+        
+        rare_ids_path = Path("./rare_structure_ids.json")
+        rare_ids_set = set(json.load(rare_ids_path.open())) if rare_ids_path.exists() else set()
+        logger.info(f"Loaded {len(rare_ids_set)} rare structure IDs.")
+
+    if not structure_ids:
+        logger.error("No structures found. Exiting.")
+        return
+
+    # --- Split Rare IDs for Val-B ---
+    val_b_frac = 0.5  # Use 50% of rare structures for the 'hard' validation set
+    num_val_b = int(len(rare_ids_set) * val_b_frac)
+    val_b_ids = set(random.sample(list(rare_ids_set), num_val_b))
+    rare_ids_for_training_pool = rare_ids_set - val_b_ids
+    logger.info(f"Assigned {len(val_b_ids)} structures to Val-B. Kept {len(rare_ids_for_training_pool)} in the main pool.")
+
+    # Indices for sampler still need to be computed based on the final training set
+    structure_id_to_index = {sid: i for i, sid in enumerate(structure_ids) if sid not in val_b_ids}
+    rare_structure_indices = [structure_id_to_index[sid] for sid in rare_ids_for_training_pool if sid in structure_id_to_index]
+
+    experiment_name = "allegro_additive_loss_study"
+    base_dir = Path(f"../data/allegro_experiments/{experiment_name}")
+
+    # --- Define Experimental Configurations ---
+    base_loss_coeffs = {
+        "total_energy": {"coeff": 1.0, "metric": "mse"},
+        "forces": {"coeff": 10.0, "metric": "auto_stratified_huber"},
+        "stress": {"coeff": 50.0, "metric": "mse"},
+    }
+
+    additive_losses = [
+        {"loss_key": "base_only", "loss": {}},
+        {"loss_key": "force_angle", "loss": {"forces_angle": {"coeff": 10.0, "metric": "force_angle", "field": "forces"}}},
+        {"loss_key": "stress_angle", "loss": {"stress_angle": {"coeff": 25.0, "metric": "stress_angle", "field": "stress"}}},
+        {"loss_key": "stress_shear", "loss": {"stress_shear": {"coeff": 25.0, "metric": "stress_shear_mae", "field": "stress"}}},
+        {"loss_key": "focal_force", "loss": {"forces_focal": {"coeff": 10.0, "metric": "focal_mse", "params": {"beta": "auto"}, "field": "forces"}}},
+    ]
+
+    sampling_configs = [
+        {"sampler_key": "no_sampler", "sampler": None},
+        {"sampler_key": "rare_sampling", "sampler": "rare_weighted", "sampler_params": {"replica": 5, "rare_idx": rare_structure_indices}},
+    ]
+    
+    for additive_config, sampling_config in product(additive_losses, sampling_configs):
+        job_name = f"{additive_config['loss_key']}_{sampling_config['sampler_key']}"
+        job_dir = base_dir / job_name
+
+        # Combine base loss with the additive component
+        final_loss_coeffs = {**base_loss_coeffs, **additive_config['loss']}
+
+        params = {
+            "job_name": job_name,
+            "structure_ids": structure_ids,
+            "val_b_ids": list(val_b_ids),
+            "train_ratio": 0.8, "val_ratio": 0.1, "test_ratio": 0.1,
+            "seed": 42,
+            "max_epochs": 150,
+            "wandb_project": experiment_name,
+            "checkpoint_monitor_key": "val1_epoch/forces_mae", # Now monitor val_b
+            "loss_coeffs": final_loss_coeffs,
+            "sampler": sampling_config["sampler"],
+            "sampler_params": sampling_config.get("sampler_params"),
+        }
+        
+        run_and_summarize(job_dir, **params)
+
+if __name__ == "__main__":
+    main()

--- a/scratch/scripts/run_allegro_loss_experiment.py
+++ b/scratch/scripts/run_allegro_loss_experiment.py
@@ -52,6 +52,7 @@ def main():
         all_ids = db_manager.find_structures_by_metadata({'generation': 0}, operator='>=')
         dimer_ids = db_manager.find_structures_by_metadata({'config_type': 'dimer'})
         structure_ids = [sid for sid in all_ids if sid not in dimer_ids]
+        structure_ids = structure_ids[:5000]
         logger.info(f"Found {len(structure_ids)} structures for the experiment.")
         
         rare_ids_path = Path("./rare_structure_ids.json")


### PR DESCRIPTION
### Summary

This pull request introduces a suite of custom loss functions and an enhanced statistics manager designed to improve model training on systems with complex potential energy surfaces, such as those containing defects. These tools provide more granular control over the training process, enabling the model to focus on specific physical properties and challenging regions within a structure.

### Motivation

A significant challenge when training models on defect-containing structures is that the strong forces in the small region around the defect can be "averaged out" by the large number of unperturbed atoms in the rest of the simulation cell. This is especially true for systems requiring large supercells to capture long-range effects, such as the 125+ atoms needed to converge vacancy formation energies in Tungsten.

Standard loss functions like MSE might not adequately penalize errors in these critical regions, leading to models that perform well on average but fail to capture the underlying physics of the defect. The components in this PR aim to address this by offering more targeted ways to evaluate and penalize errors.

### Key Features

#### 1. Extended Data Statistics Manager

The new `ExtendedDataStatisticsManager` in `forge.workflows.allegro_utils.custom_stats` automatically computes key hyperparameters from the training dataset statistics. This allows for self-tuning loss functions that adapt to the specific data they are trained on. It calculates:

*   **`huber_delta`**: The L1/L2 threshold for Huber-based losses, derived from the 95th percentile (q95) of force magnitudes.
*   **`focal_beta`**: The scaling parameter for `FocalMSELoss`, calculated as the inverse of the root-mean-square of forces.
*   **`stratified_huber_boundaries` and `stratified_huber_deltas`**: Automatically determines the bins and delta values for `AutoStratifiedHuberLoss` using the q10, q50, and q90 force magnitude quantiles.

This manager also includes significant performance optimizations for distributed (multi-GPU) training to ensure statistics are calculated efficiently and only once.

#### 2. Custom Loss Functions & Metrics

The following new metrics, located in `forge.workflows.allegro_utils.custom_metrics`, can now be used in the training configuration:

*   **`AutoStratifiedHuberLoss`**: A wrapper for NequIP's `StratifiedHuberForceLoss` that automatically builds its stratification dictionary using the boundaries and deltas computed by the `ExtendedDataStatisticsManager`.
*   **`TailMSE`**: Computes the Mean Squared Error on a "tail" of the error distribution within each batch. This helps focus training on the atoms with the highest errors, preventing them from being ignored.
*   **`TailHuberLoss`**: Similar to `TailMSE`, this metric computes the Huber loss on a high-error tail of the data, selected based on the norm of the force error vectors in each batch.
*   **`FocalMSELoss`**: A variant of MSE that applies a modulating factor to down-weight the loss from well-predicted examples, forcing the model to focus on harder examples.
*   **`ForceAngleLoss`**: Penalizes deviations in the *direction* of force vectors by computing `1 - cos(θ)`, where `θ` is the angle between predicted and target forces. This is useful for learning correct force orientations irrespective of magnitude.
*   **`StressShearMAE`**: Calculates the Mean Absolute Error on only the off-diagonal (shear) components of the stress tensor (σ_xy, σ_xz, σ_yz), which is useful for specifically targeting the C₄₄ elastic constant.
*   **`StressAngleLoss`**: Penalizes deviations in the direction of the 6D Voigt representation of the stress tensor, targeting the overall "shape" of the stress state.

### Integration & Usage

*   The `prepare_allegro_job` workflow has been updated to support these new metrics. They can be specified in the `loss_coeffs` and `extra_val_metrics` arguments.
*   The script `scratch/scripts/run_allegro_loss_experiment.py` serves as a comprehensive example, demonstrating how to systematically set up an experiment to test and compare the performance of these new loss functions.